### PR TITLE
add-featured-products-and-more

### DIFF
--- a/api/attributes/models/attributes.settings.json
+++ b/api/attributes/models/attributes.settings.json
@@ -1,40 +1,40 @@
 {
-    "kind": "collectionType",
-    "collectionName": "add_ons",
-    "info": {
-      "name": "add_ons"
+  "kind": "collectionType",
+  "collectionName": "add_ons",
+  "info": {
+    "name": "Menu_add_on"
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true
+  },
+  "attributes": {
+    "name": {
+      "type": "string"
     },
-    "options": {
-      "increments": true,
-      "timestamps": true
+    "price": {
+      "type": "decimal"
     },
-    "attributes": {
-      "name": {
-        "type": "string"
-      },
-      "price": {
-        "type": "decimal"
-      },
-      "stock": {
-        "type": "integer"
-      },
-      "sku": {
-        "type": "string"
-      },
-      "image": {
-        "collection": "file",
-        "via": "related",
-        "allowedTypes": [
-          "images",
-          "files",
-          "videos"
-        ],
-        "plugin": "upload",
-        "required": false
-      },
-      "product": {
-        "model": "products",
-        "via": "add_ons"
-      }
+    "stock": {
+      "type": "integer"
+    },
+    "sku": {
+      "type": "string"
+    },
+    "image": {
+      "collection": "file",
+      "via": "related",
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos"
+      ],
+      "plugin": "upload",
+      "required": false
+    },
+    "product": {
+      "model": "products",
+      "via": "add_ons"
     }
   }
+}

--- a/api/categories/models/categories.settings.json
+++ b/api/categories/models/categories.settings.json
@@ -2,7 +2,7 @@
   "kind": "collectionType",
   "collectionName": "categories",
   "info": {
-    "name": "Categories"
+    "name": "Menu_Section"
   },
   "options": {
     "increments": true,
@@ -13,7 +13,7 @@
       "type": "string",
       "required": true
     },
-    "description": {
+    "about": {
       "type": "richtext"
     },
     "image": {
@@ -35,8 +35,8 @@
       "collection": "restaurant"
     },
     "offers": {
-      "via": "categories",
-      "collection": "offer"
+      "collection": "offer",
+      "via": "categories"
     }
   }
 }

--- a/api/offer/models/offer.settings.json
+++ b/api/offer/models/offer.settings.json
@@ -19,16 +19,16 @@
       "type": "datetime"
     },
     "categories": {
-      "collection": "categories",
       "via": "offers",
+      "collection": "categories",
       "dominant": true
     },
     "eligibleTransactionVolume": {
       "type": "decimal"
     },
     "products": {
-      "collection": "products",
       "via": "offers",
+      "collection": "products",
       "dominant": true
     },
     "price": {

--- a/api/products/models/products.settings.json
+++ b/api/products/models/products.settings.json
@@ -2,7 +2,7 @@
   "kind": "collectionType",
   "collectionName": "products",
   "info": {
-    "name": "Products"
+    "name": "Menu_Item"
   },
   "options": {
     "increments": true,
@@ -86,8 +86,16 @@
       "collection": "attributes"
     },
     "offers": {
-      "via": "products",
-      "collection": "offer"
+      "collection": "offer",
+      "via": "products"
+    },
+    "Featured": {
+      "type": "boolean",
+      "default": false,
+      "required": false
+    },
+    "suitable_for_diet": {
+      "type": "string"
     }
   }
 }

--- a/api/restaurant/models/restaurant.settings.json
+++ b/api/restaurant/models/restaurant.settings.json
@@ -46,7 +46,7 @@
       "repeatable": true,
       "component": "restaurants.meta"
     },
-    "Content": {
+    "Type": {
       "type": "dynamiczone",
       "components": [
         "restaurants.meta"
@@ -58,17 +58,10 @@
     "Delivery_fee": {
       "type": "integer"
     },
-    "Type": {
-      "type": "enumeration",
-      "enum": [
-        "vegetarian",
-        "vegan",
-        "spicey",
-        "plastic_free",
-        "gluten_free",
-        "dairy_free",
-        "cambodian_owned"
-      ]
+    "Visible": {
+      "type": "boolean",
+      "default": false,
+      "required": true
     }
   }
 }

--- a/api/restaurant/models/restaurant.settings.json
+++ b/api/restaurant/models/restaurant.settings.json
@@ -41,16 +41,10 @@
       "collection": "offer",
       "via": "restaurants"
     },
-    "Meta": {
+    "Type": {
       "type": "component",
       "repeatable": true,
       "component": "restaurants.meta"
-    },
-    "Type": {
-      "type": "dynamiczone",
-      "components": [
-        "restaurants.meta"
-      ]
     },
     "Delivery_time": {
       "type": "integer"
@@ -61,7 +55,7 @@
     "Visible": {
       "type": "boolean",
       "default": false,
-      "required": true
+      "required": false
     }
   }
 }

--- a/api/variations/models/variations.settings.json
+++ b/api/variations/models/variations.settings.json
@@ -1,44 +1,43 @@
 {
-    "kind": "collectionType",
-    "collectionName": "variations",
-    "info": {
-      "name": "variations"
+  "kind": "collectionType",
+  "collectionName": "variations",
+  "info": {
+    "name": "variations"
+  },
+  "options": {
+    "increments": true,
+    "timestamps": true
+  },
+  "attributes": {
+    "name": {
+      "type": "string"
     },
-    "options": {
-      "increments": true,
-      "timestamps": true
+    "price": {
+      "type": "decimal"
     },
-    "attributes": {
-      "name": {
-        "type": "string"
-      },
-      "price": {
-        "type": "decimal"
-      },
-      "stock": {
-        "type": "integer"
-      },
-      "weight": {
-        "type": "decimal"
-      },
-      "sku": {
-        "type": "string"
-      },
-      "image": {
-        "collection": "file",
-        "via": "related",
-        "allowedTypes": [
-          "images",
-          "files",
-          "videos"
-        ],
-        "plugin": "upload",
-        "required": false
-      },
-      "product": {
-        "via": "variations",
-        "model": "products"
-      }
+    "stock": {
+      "type": "integer"
+    },
+    "weight": {
+      "type": "decimal"
+    },
+    "sku": {
+      "type": "string"
+    },
+    "image": {
+      "collection": "file",
+      "via": "related",
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos"
+      ],
+      "plugin": "upload",
+      "required": false
+    },
+    "product": {
+      "via": "variations",
+      "model": "products"
     }
   }
-  
+}

--- a/components/restaurants/meta.json
+++ b/components/restaurants/meta.json
@@ -6,8 +6,20 @@
   },
   "options": {},
   "attributes": {
-    "Tag": {
-      "type": "string"
+    "Category": {
+      "type": "enumeration",
+      "enum": [
+        "western",
+        "indian",
+        "cambodian",
+        "burger",
+        "pizza",
+        "swiss",
+        "hungarian",
+        "vegetarian_vegan",
+        "plastic_free",
+        "italian"
+      ]
     }
   }
 }


### PR DESCRIPTION
For home page API
removed additional meta data "type" from resturaunt, we only need a category selection... I can add more categories as we onboard.
added visible so we can toggle resturaunts live or not

changed "products" to be menu items to match schema.org, minor changes in naming there to match schema.org